### PR TITLE
Add support for expressions in macros.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### v0.4.0 (2025-04-29) - (unreleased)
+
+- [added] Support for macro expressions.  See `MacroDecimal`.
 
 ### v0.3.0 (2022-07-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gerber-types"
-version = "0.3.0"
+version = "0.4.0"
 documentation = "https://docs.rs/gerber-types/"
 repository = "https://github.com/MakerPnP/gerber-types-rs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Hi,

I'm currently writing a gerber viewer in rust, using the gerber_parser crate, while adding support for aperture macros I noticed the MacroDecimal doesn't support expressions.

Example from 2021.02 Gerber spec, section: 4.5.4.2:
```
%AMRect*
21,1,$1,$2-2*$3,-$4,-$5+$2,0*%
%ADD146Rect,0.0807087X0.1023622X0.0118110X0.5000000X0.3000000*%
```

This is a pretty trivial change, but it is a breaking change as it adds an enum variant.