### PR TITLE
Macro improvements 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### v0.4.0 (2025-04-29) - (unreleased)
+
+- [added] Support for macro expressions.  See `MacroDecimal`.
 
 ### v0.3.0 (2022-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ### v0.4.0 (2025-04-29) - (unreleased)
 
 - [added] Support for macro expressions.  See `MacroDecimal`.
+- [changed] Replaced `Aperture::Other` with `Aperture::Macro`, the latter having option arguments. 
 
 ### v0.3.0 (2022-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ Possible log types:
 ### v0.4.0 (2025-04-29) - (unreleased)
 
 - [added] Support for macro expressions.  See `MacroDecimal`.
-- [changed] Replaced `Aperture::Other` with `Aperture::Macro`, the latter having option arguments. 
+- [added] `MacroBoolean`.
+- [added] `MacroInteger`.
+- [changed] Replaced `Aperture::Other` with `Aperture::Macro`, the latter having option arguments.
+- [changed] Use `MacroBoolean` instead of `bool` for `exposure` on macro primitives.
+- [changed] `PolygonPrimitive::new` uses a `MacroInteger` for the `vertices` argument.
+- [deprecated] `*Primitive::exposure_on`, replaced with `*Primitive::with_exposure`.
 
 ### v0.3.0 (2022-07-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gerber-types"
-version = "0.3.0"
+version = "0.4.0"
 documentation = "https://docs.rs/gerber-types/"
 repository = "https://github.com/MakerPnP/gerber-types-rs"
 license = "MIT OR Apache-2.0"

--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -110,12 +110,12 @@ fn main() {
         .into(),
         ExtendedCode::ApertureDefinition(ApertureDefinition {
             code: 18,
-            aperture: Aperture::Other("TARGET125".to_string()),
+            aperture: Aperture::Macro("TARGET125".to_string(), None),
         })
         .into(),
         ExtendedCode::ApertureDefinition(ApertureDefinition {
             code: 19,
-            aperture: Aperture::Other("THERMAL80".to_string()),
+            aperture: Aperture::Macro("THERMAL80".to_string(), None),
         })
         .into(),
         FunctionCode::GCode(GCode::Comment("Start image generation".to_string())).into(),

--- a/src/extended_codes.rs
+++ b/src/extended_codes.rs
@@ -53,7 +53,7 @@ pub enum Aperture {
     Rectangle(Rectangular),
     Obround(Rectangular),
     Polygon(Polygon),
-    Other(String),
+    Macro(String, Option<String>),
 }
 
 impl<W: Write> PartialGerberCode<W> for Aperture {
@@ -75,7 +75,12 @@ impl<W: Write> PartialGerberCode<W> for Aperture {
                 write!(writer, "P,")?;
                 polygon.serialize_partial(writer)?;
             }
-            Aperture::Other(ref string) => write!(writer, "{}", string)?,
+            Aperture::Macro(ref string, ref args) => {
+                write!(writer, "{}", string)?;
+                if let Some(ref args) = *args {
+                    write!(writer, ",{}", args)?;
+                }
+            }
         };
         Ok(())
     }

--- a/src/extended_codes.rs
+++ b/src/extended_codes.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 
 use crate::errors::GerberResult;
 use crate::traits::PartialGerberCode;
+use crate::MacroDecimal;
 
 // Unit
 
@@ -53,7 +54,15 @@ pub enum Aperture {
     Rectangle(Rectangular),
     Obround(Rectangular),
     Polygon(Polygon),
-    Macro(String, Option<String>),
+
+    /// gerber spec (2024.05) 4.3.1 "AD Command" - "Parameters are decimals."
+    ///
+    /// Note: this definition conflicts with:
+    /// a) the [`MacroBoolean`] which is used for the exposure parameter for macro primitives.
+    /// b) the [`MacroInteger`] which is used for the '# vertices' parameter for macro primitives.
+    ///
+    /// Conversion functions from MacroDecimal to [`MacroBoolean`] & [`MacroInteger`] are required.  
+    Macro(String, Option<Vec<MacroDecimal>>),
 }
 
 impl<W: Write> PartialGerberCode<W> for Aperture {
@@ -78,7 +87,13 @@ impl<W: Write> PartialGerberCode<W> for Aperture {
             Aperture::Macro(ref string, ref args) => {
                 write!(writer, "{}", string)?;
                 if let Some(ref args) = *args {
-                    write!(writer, ",{}", args)?;
+                    write!(writer, ",")?;
+                    for (index, arg) in args.iter().enumerate() {
+                        if index > 0 {
+                            write!(writer, "X")?;
+                        }
+                        arg.serialize_partial(writer)?;
+                    }
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,20 @@ mod test {
     }
 
     #[test]
+    fn test_aperture_macro_definition() {
+        let m1 = ApertureDefinition {
+            code: 42,
+            aperture: Aperture::Macro("NO_ARGS1".to_string(), None),
+        };
+        let m2 = ApertureDefinition {
+            code: 69,
+            aperture: Aperture::Macro("With_Args2".to_string(), Some("$1X0.25X$1x$2".to_string())),
+        };
+        assert_partial_code!(m1, "42NO_ARGS1");
+        assert_partial_code!(m2, "69With_Args2,$1X0.25X$1x$2");
+    }
+
+    #[test]
     fn test_polarity_serialize() {
         let d = ExtendedCode::LoadPolarity(Polarity::Dark);
         let c = ExtendedCode::LoadPolarity(Polarity::Clear);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,14 @@ mod test {
         };
         let m2 = ApertureDefinition {
             code: 69,
-            aperture: Aperture::Macro("With_Args2".to_string(), Some("$1X0.25X$1x$2".to_string())),
+            aperture: Aperture::Macro(
+                "With_Args2".to_string(),
+                Some(vec![
+                    MacroDecimal::Variable(1),
+                    MacroDecimal::Value(0.25),
+                    MacroDecimal::Expression("$1x$2".to_string()),
+                ]),
+            ),
         };
         assert_partial_code!(m1, "42NO_ARGS1");
         assert_partial_code!(m2, "69With_Args2,$1X0.25X$1x$2");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ mod traits;
 mod types;
 
 pub use crate::attributes::*;
-pub use crate::codegen::*;
 pub use crate::coordinates::*;
 pub use crate::errors::*;
 pub use crate::extended_codes::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -127,6 +127,36 @@ impl<W: Write> PartialGerberCode<W> for MacroBoolean {
     }
 }
 
+impl From<MacroDecimal> for MacroBoolean {
+    fn from(value: MacroDecimal) -> Self {
+        match value {
+            MacroDecimal::Value(decimal) => Self::Value(decimal == 1.0),
+            MacroDecimal::Variable(variable) => Self::Variable(variable),
+            MacroDecimal::Expression(expressions) => Self::Expression(expressions),
+        }
+    }
+}
+
+#[test]
+fn test_macro_boolean_from_decimal() {
+    assert_eq!(
+        MacroBoolean::from(MacroDecimal::Value(1.0)),
+        MacroBoolean::Value(true)
+    );
+    assert_eq!(
+        MacroBoolean::from(MacroDecimal::Value(0.0)),
+        MacroBoolean::Value(false)
+    );
+    assert_eq!(
+        MacroBoolean::from(MacroDecimal::Variable(42)),
+        MacroBoolean::Variable(42)
+    );
+    assert_eq!(
+        MacroBoolean::from(MacroDecimal::Expression("$1x$2".to_string())),
+        MacroBoolean::Expression("$1x$2".to_string())
+    );
+}
+
 /// Gerber specification (2021.02 - 2024.05) 3.4.1 Integers
 /// "Integers must fit in a 32-bit signed integer"
 #[derive(Debug, Clone, PartialEq)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -295,6 +295,7 @@ impl CirclePrimitive {
     }
 
     #[deprecated(since = "0.4.0", note = "Use `with_exposure` instead")]
+    #[allow(unused_mut)]
     pub fn exposure_on(mut self, exposure: bool) -> Self {
         self.with_exposure(MacroBoolean::Value(exposure))
     }
@@ -363,6 +364,7 @@ impl VectorLinePrimitive {
     }
 
     #[deprecated(since = "0.4.0", note = "Use `with_exposure` instead")]
+    #[allow(unused_mut)]
     pub fn exposure_on(mut self, exposure: bool) -> Self {
         self.with_exposure(MacroBoolean::Value(exposure))
     }
@@ -434,6 +436,7 @@ impl CenterLinePrimitive {
     }
 
     #[deprecated(since = "0.4.0", note = "Use `with_exposure` instead")]
+    #[allow(unused_mut)]
     pub fn exposure_on(mut self, exposure: bool) -> Self {
         self.with_exposure(MacroBoolean::Value(exposure))
     }
@@ -592,6 +595,7 @@ impl PolygonPrimitive {
     }
 
     #[deprecated(since = "0.4.0", note = "Use `with_exposure` instead")]
+    #[allow(unused_mut)]
     pub fn exposure_on(mut self, exposure: bool) -> Self {
         self.with_exposure(MacroBoolean::Value(exposure))
     }
@@ -1104,7 +1108,8 @@ mod test {
 
     #[test]
     fn test_centerline_primitive_new() {
-        let cl1 = CenterLinePrimitive::new((Value(3.0), Value(4.5))).exposure_on(false);
+        let cl1 = CenterLinePrimitive::new((Value(3.0), Value(4.5)))
+            .with_exposure(MacroBoolean::Value(false));
         let cl2 = CenterLinePrimitive {
             exposure: MacroBoolean::Value(false),
             dimensions: (Value(3.0), Value(4.5)),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -868,8 +868,8 @@ impl<W: Write> PartialGerberCode<W> for ThermalPrimitive {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableDefinition {
-    number: u32,
-    expression: String,
+    pub number: u32,
+    pub expression: String,
 }
 
 impl VariableDefinition {


### PR DESCRIPTION
This PR includes commits from #35 and adds additional commits.

Changelog as follows:

```
- [added] Support for macro expressions.  See `MacroDecimal`.
- [added] `MacroBoolean`.
- [added] `MacroInteger`.
- [changed] Replaced `Aperture::Other` with `Aperture::Macro`, the latter having option arguments.
- [changed] Use `MacroBoolean` instead of `bool` for `exposure` on macro primitives.
- [changed] `PolygonPrimitive::new` uses a `MacroInteger` for the `vertices` argument.
- [deprecated] `*Primitive::exposure_on`, replaced with `*Primitive::with_exposure`.
```

The gerber spec 2021.02 in 4.3.1 specified `template_name` as "The name of the template, either a standard aperture or macro". There is no 'Other'.

PR STATUS:
I've added better macro support to gerber_parser, it can now parse KiCad 8 and Diptrace 4.3 macros, using the above changes.

✅ Ready for review.